### PR TITLE
Enable basic authentication with holding user

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,17 @@ Base monorepo providing backend, frontend and AWS infrastructure to build an e-c
 ## Frontend
 - **React** + **Vite** with **TypeScript**.
 - **Tailwind CSS** and **Ant Design** for UI components.
+  
+### Login
+The frontend now includes a minimalist login page using Ant Design. Use the `holding`/`password` credentials to access privileged actions.
 
 ## Infrastructure
 - Terraform scripts under `infrastructure/aws` to provision S3 and RDS instances.
 
 This repository only contains the starting point for further development.
+
+## Authentication
+- Basic HTTP authentication using Spring Security.
+- Profile **HOLDING_USER** can log in with username `holding` and password `password`.
+- Guests can access read-only endpoints without logging in.
+- Support for an **EXECUTIVE** role will be added later.

--- a/backend/src/main/java/com/parcel/ecommerce/config/SecurityConfig.java
+++ b/backend/src/main/java/com/parcel/ecommerce/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.parcel.ecommerce.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Basic security configuration enabling HTTP Basic authentication for the
+ * HOLDING_USER profile. Guests can access read-only endpoints without login.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails holdingUser = User.withUsername("holding")
+                .password("{noop}password")
+                .roles("HOLDING_USER")
+                .build();
+        return new InMemoryUserDetailsManager(holdingUser);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.POST, "/api/**").hasRole("HOLDING_USER")
+                .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
+                .anyRequest().permitAll())
+            .httpBasic();
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/parcel/ecommerce/domain/UserRole.java
+++ b/backend/src/main/java/com/parcel/ecommerce/domain/UserRole.java
@@ -1,0 +1,11 @@
+package com.parcel.ecommerce.domain;
+
+/**
+ * Roles available in the system. Currently only HOLDING_USER is used for
+ * authentication. Guests access the API without login. EXECUTIVE will be
+ * incorporated in the future.
+ */
+public enum UserRole {
+    HOLDING_USER,
+    EXECUTIVE
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from 'antd';
+import LoginForm from './LoginForm';
 
-const App: React.FC = () => (
-  <div className="p-4">
-    <h1 className="text-2xl font-bold mb-4">Parcel E-Commerce</h1>
-    <Button type="primary">Explore Parcels</Button>
-  </div>
-);
+const App: React.FC = () => {
+  const [credentials, setCredentials] = useState<{ username: string; password: string } | null>(null);
+
+  const handleLogin = (username: string, password: string) => {
+    setCredentials({ username, password });
+  };
+
+  if (!credentials) {
+    return <LoginForm onLogin={handleLogin} />;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Parcel E-Commerce</h1>
+      <Button type="primary">Explore Parcels</Button>
+    </div>
+  );
+};
 
 export default App;

--- a/frontend/src/LoginForm.tsx
+++ b/frontend/src/LoginForm.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Form, Input, Button } from 'antd';
+
+interface LoginFormProps {
+  onLogin: (username: string, password: string) => void;
+}
+
+const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
+  const onFinish = (values: any) => {
+    onLogin(values.username, values.password);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <Form
+        name="login"
+        onFinish={onFinish}
+        className="p-6 bg-white shadow-md rounded w-80"
+      >
+        <Form.Item
+          name="username"
+          rules={[{ required: true, message: 'Please input your username!' }]}
+        >
+          <Input placeholder="Username" />
+        </Form.Item>
+        <Form.Item
+          name="password"
+          rules={[{ required: true, message: 'Please input your password!' }]}
+        >
+          <Input.Password placeholder="Password" />
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" htmlType="submit" className="w-full">
+            Log in
+          </Button>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,4 @@
+@import 'antd/dist/reset.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- secure backend using Spring Security
- add HOLDING_USER login and reserved EXECUTIVE role
- document authentication and guest access in the README
- add modern minimalist login page in React frontend

## Testing
- `mvn -q test` *(fails: mvn: command not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407fdcf6fc8333bc965fb128331344